### PR TITLE
DSND-696 - Expose insolvency delete endpoint

### DIFF
--- a/src/itest/java/uk/gov/companieshouse/insolvency/data/steps/InsolvencySteps.java
+++ b/src/itest/java/uk/gov/companieshouse/insolvency/data/steps/InsolvencySteps.java
@@ -88,6 +88,19 @@ public class InsolvencySteps {
         CucumberContext.CONTEXT.set("statusCode", response.getStatusCodeValue());
     }
 
+    @When("I send DELETE request with company number {string}")
+    public void i_send_delete_request_with_company_number(String companyNumber) throws IOException {
+        String uri = "/company/{company_number}/insolvency";
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.set("x-request-id", "5234234234");
+        var request = new HttpEntity<>(null, headers);
+
+        ResponseEntity<Void> response = restTemplate.exchange(uri, HttpMethod.DELETE, request, Void.class, companyNumber);
+
+        CucumberContext.CONTEXT.set("statusCode", response.getStatusCodeValue());
+    }
+
     @Then("I should receive {int} status code")
     public void i_should_receive_status_code(Integer statusCode) {
         int expectedStatusCode = CucumberContext.CONTEXT.get("statusCode");

--- a/src/itest/resources/features/company-insolvency.feature
+++ b/src/itest/resources/features/company-insolvency.feature
@@ -23,3 +23,14 @@ Feature: Process company insolvency information
     Examples:
       | companyNumber | result                     |
       | CH3634545     | retrieve_by_company_number |
+
+  Scenario Outline: Delete company insolvency information successfully
+
+    Given Insolvency data api service is running
+    And the insolvency information exists for "<companyNumber>"
+    When I send DELETE request with company number "<companyNumber>"
+    Then I should receive 200 status code
+
+    Examples:
+      | companyNumber |
+      | CH3634545     |

--- a/src/main/java/uk/gov/companieshouse/insolvency/data/controller/InsolvencyController.java
+++ b/src/main/java/uk/gov/companieshouse/insolvency/data/controller/InsolvencyController.java
@@ -3,6 +3,7 @@ package uk.gov.companieshouse.insolvency.data.controller;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PutMapping;
@@ -69,6 +70,25 @@ public class InsolvencyController {
                 companyNumber);
 
         return ResponseEntity.status(HttpStatus.OK).body(companyInsolvency);
+    }
+
+    /**
+     * Retrieve company insolvency information for a company number.
+     *
+     * @param  companyNumber  the company number for insolvency
+     * @return  {@link CompanyInsolvency} return company insolvency information
+     */
+    @DeleteMapping("/company/{company_number}/insolvency")
+    public ResponseEntity<Void> insolvency(
+            @RequestHeader("x-request-id") String contextId,
+            @PathVariable("company_number") String companyNumber) {
+        logger.info(String.format(
+                "Deleting company insolvency information for company number %s",
+                companyNumber));
+
+        insolvencyService.deleteInsolvency(contextId, companyNumber);
+
+        return ResponseEntity.status(HttpStatus.OK).build();
     }
 
 }

--- a/src/main/java/uk/gov/companieshouse/insolvency/data/service/InsolvencyService.java
+++ b/src/main/java/uk/gov/companieshouse/insolvency/data/service/InsolvencyService.java
@@ -18,4 +18,5 @@ public interface InsolvencyService {
 
     CompanyInsolvency retrieveCompanyInsolvency(String companyNumber);
 
+    void deleteInsolvency(String contextId, String companyNumber);
 }

--- a/src/main/java/uk/gov/companieshouse/insolvency/data/service/InsolvencyServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/insolvency/data/service/InsolvencyServiceImpl.java
@@ -116,7 +116,7 @@ public class InsolvencyServiceImpl implements InsolvencyService {
     @Override
     public void deleteInsolvency(String contextId, String companyNumber) {
         logger.info(String.format(
-                "Company insolvency deleted successfully for company number %s",
+                "Company insolvency delete called for company number %s",
                 companyNumber));
         try {
             insolvencyRepository.deleteById(companyNumber);

--- a/src/main/java/uk/gov/companieshouse/insolvency/data/service/InsolvencyServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/insolvency/data/service/InsolvencyServiceImpl.java
@@ -113,6 +113,18 @@ public class InsolvencyServiceImpl implements InsolvencyService {
         return insolvencyDocument.getCompanyInsolvency();
     }
 
+    @Override
+    public void deleteInsolvency(String contextId, String companyNumber) {
+        logger.info(String.format(
+                "Company insolvency deleted successfully for company number %s",
+                companyNumber));
+        try {
+            insolvencyRepository.deleteById(companyNumber);
+        } catch (DataAccessException dbException) {
+            throw new ServiceUnavailableException(dbException.getMessage());
+        }
+    }
+
     private InsolvencyDocument mapInsolvencyDocument(String companyNumber,
                                                      InternalCompanyInsolvency insolvencyApi) {
         InternalData internalData = insolvencyApi.getInternalData();

--- a/src/main/java/uk/gov/companieshouse/insolvency/data/service/InsolvencyServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/insolvency/data/service/InsolvencyServiceImpl.java
@@ -118,11 +118,6 @@ public class InsolvencyServiceImpl implements InsolvencyService {
         logger.info(String.format(
                 "Company insolvency delete called for company number %s",
                 companyNumber));
-        try {
-            insolvencyRepository.deleteById(companyNumber);
-        } catch (DataAccessException dbException) {
-            throw new ServiceUnavailableException(dbException.getMessage());
-        }
     }
 
     private InsolvencyDocument mapInsolvencyDocument(String companyNumber,

--- a/src/main/java/uk/gov/companieshouse/insolvency/data/service/NoopTransactionServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/insolvency/data/service/NoopTransactionServiceImpl.java
@@ -108,6 +108,18 @@ public class NoopTransactionServiceImpl implements InsolvencyService {
         return insolvencyDocument.getCompanyInsolvency();
     }
 
+    @Override
+    public void deleteInsolvency(String contextId, String companyNumber) {
+        logger.info(String.format(
+                "Company insolvency deleted successfully for company number %s",
+                companyNumber));
+        try {
+            insolvencyRepository.deleteById(companyNumber);
+        } catch (DataAccessException dbException) {
+            throw new ServiceUnavailableException(dbException.getMessage());
+        }
+    }
+
     private InsolvencyDocument mapInsolvencyDocument(String companyNumber,
                                                      InternalCompanyInsolvency insolvencyApi) {
         InternalData internalData = insolvencyApi.getInternalData();

--- a/src/main/java/uk/gov/companieshouse/insolvency/data/service/NoopTransactionServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/insolvency/data/service/NoopTransactionServiceImpl.java
@@ -113,11 +113,6 @@ public class NoopTransactionServiceImpl implements InsolvencyService {
         logger.info(String.format(
                 "Company insolvency delete called for company number %s",
                 companyNumber));
-        try {
-            insolvencyRepository.deleteById(companyNumber);
-        } catch (DataAccessException dbException) {
-            throw new ServiceUnavailableException(dbException.getMessage());
-        }
     }
 
     private InsolvencyDocument mapInsolvencyDocument(String companyNumber,

--- a/src/main/java/uk/gov/companieshouse/insolvency/data/service/NoopTransactionServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/insolvency/data/service/NoopTransactionServiceImpl.java
@@ -111,7 +111,7 @@ public class NoopTransactionServiceImpl implements InsolvencyService {
     @Override
     public void deleteInsolvency(String contextId, String companyNumber) {
         logger.info(String.format(
-                "Company insolvency deleted successfully for company number %s",
+                "Company insolvency delete called for company number %s",
                 companyNumber));
         try {
             insolvencyRepository.deleteById(companyNumber);

--- a/src/test/java/uk/gov/companieshouse/insolvency/data/controller/InsolvencyControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/insolvency/data/controller/InsolvencyControllerTest.java
@@ -30,6 +30,7 @@ import static org.mockito.ArgumentMatchers.isA;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doThrow;
 import static org.springframework.http.MediaType.APPLICATION_JSON;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -164,5 +165,16 @@ public class InsolvencyControllerTest {
                         .header("x-request-id", "5342342")
                         .content(gson.toJson(request)))
                 .andExpect(status().isServiceUnavailable());
+    }
+
+    @Test
+    @DisplayName("Insolvency DELETE request")
+    public void callInsolvencyDeleteRequest() throws Exception {
+        doNothing().when(insolvencyService).deleteInsolvency(anyString(), anyString());
+
+        mockMvc.perform(delete(URL)
+                        .contentType(APPLICATION_JSON)
+                        .header("x-request-id", "5342342"))
+                .andExpect(status().isOk());
     }
 }

--- a/src/test/java/uk/gov/companieshouse/insolvency/data/service/InsolvencyServiceImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/insolvency/data/service/InsolvencyServiceImplTest.java
@@ -98,21 +98,12 @@ class InsolvencyServiceImplTest {
     @Test
     void when_insolvency_number_is_given_then_delete_company_insolvency_successfully() {
         String companyNumber = "CH363453";
-        doNothing().when(repository).deleteById(companyNumber);
 
         underTest.deleteInsolvency("436534543", companyNumber);
 
-        verify(repository, Mockito.times(1)).deleteById(Mockito.any());
-    }
-
-    @Test
-    void when_delete_and_connection_issue_in_db_then_throw_service_unavailable_exception() {
-        doThrow(new DataAccessResourceFailureException("Connection broken"))
-                .when(repository)
-                .deleteById("CH363453");
-
-        assertThrows(ServiceUnavailableException.class, () ->
-                underTest.deleteInsolvency("436534543", "CH363453"));
+        verify(logger, Mockito.times(1)).info(
+                "Company insolvency delete called for company number " + companyNumber
+        );
     }
 
 

--- a/src/test/java/uk/gov/companieshouse/insolvency/data/service/InsolvencyServiceImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/insolvency/data/service/InsolvencyServiceImplTest.java
@@ -95,6 +95,26 @@ class InsolvencyServiceImplTest {
         Mockito.verify(repository, Mockito.times(1)).findById(Mockito.any());
     }
 
+    @Test
+    void when_insolvency_number_is_given_then_delete_company_insolvency_successfully() {
+        String companyNumber = "CH363453";
+        Mockito.doNothing().when(repository).deleteById(companyNumber);
+
+        underTest.deleteInsolvency("436534543", companyNumber);
+
+        Mockito.verify(repository, Mockito.times(1)).deleteById(Mockito.any());
+    }
+
+    @Test
+    void when_delete_and_connection_issue_in_db_then_throw_service_unavailable_exception() {
+        doThrow(new DataAccessResourceFailureException("Connection broken"))
+                .when(repository)
+                .deleteById("CH363453");
+
+        Assert.assertThrows(ServiceUnavailableException.class, () ->
+                underTest.deleteInsolvency("436534543", "CH363453"));
+    }
+
 
     private InternalCompanyInsolvency createInternalCompanyInsolvency() {
         InternalCompanyInsolvency companyInsolvency = new InternalCompanyInsolvency();

--- a/src/test/java/uk/gov/companieshouse/insolvency/data/service/InsolvencyServiceImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/insolvency/data/service/InsolvencyServiceImplTest.java
@@ -23,9 +23,9 @@ import uk.gov.companieshouse.insolvency.data.model.InsolvencyDocument;
 import uk.gov.companieshouse.insolvency.data.repository.InsolvencyRepository;
 import uk.gov.companieshouse.logging.Logger;
 
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.isA;
-import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
 class InsolvencyServiceImplTest {
@@ -48,7 +48,7 @@ class InsolvencyServiceImplTest {
 
         underTest.processInsolvency("436534543", "CH363453", companyInsolvency);
 
-        Mockito.verify(repository, Mockito.times(1)).save(Mockito.any());
+        verify(repository, Mockito.times(1)).save(Mockito.any());
     }
 
     @Test
@@ -72,7 +72,7 @@ class InsolvencyServiceImplTest {
         CompanyInsolvency companyInsolvency = underTest.retrieveCompanyInsolvency("234234");
 
         Assertions.assertThat(companyInsolvency).isNotNull();
-        Mockito.verify(repository, Mockito.times(1)).findById(Mockito.any());
+        verify(repository, Mockito.times(1)).findById(Mockito.any());
     }
 
     @Test
@@ -92,17 +92,17 @@ class InsolvencyServiceImplTest {
         Assert.assertThrows(RuntimeException.class, () -> underTest.retrieveCompanyInsolvency
                 ("CH4000056"));
 
-        Mockito.verify(repository, Mockito.times(1)).findById(Mockito.any());
+        verify(repository, Mockito.times(1)).findById(Mockito.any());
     }
 
     @Test
     void when_insolvency_number_is_given_then_delete_company_insolvency_successfully() {
         String companyNumber = "CH363453";
-        Mockito.doNothing().when(repository).deleteById(companyNumber);
+        doNothing().when(repository).deleteById(companyNumber);
 
         underTest.deleteInsolvency("436534543", companyNumber);
 
-        Mockito.verify(repository, Mockito.times(1)).deleteById(Mockito.any());
+        verify(repository, Mockito.times(1)).deleteById(Mockito.any());
     }
 
     @Test
@@ -111,7 +111,7 @@ class InsolvencyServiceImplTest {
                 .when(repository)
                 .deleteById("CH363453");
 
-        Assert.assertThrows(ServiceUnavailableException.class, () ->
+        assertThrows(ServiceUnavailableException.class, () ->
                 underTest.deleteInsolvency("436534543", "CH363453"));
     }
 


### PR DESCRIPTION
- Expose a `DELETE` endpoint matching the following url pattern `/company/{company_number}/insolvency`
  - No request body required
- Pass `company_number` and `x-request-id` to the insolvency service
  - merely a placeholder for now - the proper call to mongo DB will be handled in DSND-623, and the Kafka API invocations in DSND-624
- Returns response code 200 (to be amended in the aforesaid tickets)
- placeholder integration test scenario also added