### PR TITLE
DSND-711 - Non-200 response codes for insolvency delete

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -116,7 +116,6 @@
 			<groupId>org.assertj</groupId>
 			<artifactId>assertj-core</artifactId>
 			<version>${assertj-core.version}</version>
-			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.testcontainers</groupId>
@@ -135,15 +134,6 @@
 		<dependency>
 			<groupId>org.mockito</groupId>
 			<artifactId>mockito-core</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.assertj</groupId>
-			<artifactId>assertj-core</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>uk.gov.companieshouse</groupId>
-			<artifactId>private-api-sdk-java</artifactId>
-			<version>${private-api-sdk-java.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>io.cucumber</groupId>
@@ -222,6 +212,7 @@
 			<plugin>
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-maven-plugin</artifactId>
+				<version>${spring.boot.version}</version>
 				<configuration>
 					<mainClass>${main.class}</mainClass>
 				</configuration>

--- a/src/itest/java/uk/gov/companieshouse/insolvency/data/steps/InsolvencySteps.java
+++ b/src/itest/java/uk/gov/companieshouse/insolvency/data/steps/InsolvencySteps.java
@@ -108,7 +108,7 @@ public class InsolvencySteps {
         this.contextId = "5234234234";
         headers.set("x-request-id", this.contextId);
 
-        HttpEntity request = new HttpEntity(companyInsolvency, headers);
+        HttpEntity<?> request = new HttpEntity<>(companyInsolvency, headers);
         String uri = "/company/{company_number}/insolvency";
         String companyNumber = "CH5324324";
         ResponseEntity<Void> response = restTemplate.exchange(uri, HttpMethod.PUT, request, Void.class, companyNumber);
@@ -129,7 +129,7 @@ public class InsolvencySteps {
         this.contextId = "5234234234";
         headers.set("x-request-id", this.contextId);
 
-        HttpEntity request = new HttpEntity(raw_payload, headers);
+        HttpEntity<?> request = new HttpEntity<>(raw_payload, headers);
         String uri = "/company/{company_number}/insolvency";
         String companyNumber = "CH5324324";
         ResponseEntity<Void> response = restTemplate.exchange(uri, HttpMethod.PUT, request, Void.class, companyNumber);

--- a/src/main/java/uk/gov/companieshouse/insolvency/data/config/ExceptionHandlerConfig.java
+++ b/src/main/java/uk/gov/companieshouse/insolvency/data/config/ExceptionHandlerConfig.java
@@ -4,7 +4,6 @@ import java.time.LocalDateTime;
 import java.time.format.DateTimeParseException;
 import java.util.LinkedHashMap;
 import java.util.Map;
-import java.util.UUID;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
@@ -44,7 +43,7 @@ public class ExceptionHandlerConfig {
         responseBody.put("timestamp", LocalDateTime.now());
         responseBody.put("message", "Unable to process the request.");
         request.setAttribute("javax.servlet.error.exception", ex, 0);
-        return new ResponseEntity(responseBody, HttpStatus.INTERNAL_SERVER_ERROR);
+        return new ResponseEntity<>(responseBody, HttpStatus.INTERNAL_SERVER_ERROR);
     }
 
     /**
@@ -63,7 +62,7 @@ public class ExceptionHandlerConfig {
         responseBody.put("timestamp", LocalDateTime.now());
         responseBody.put("message", "Resource not found.");
         request.setAttribute("javax.servlet.error.exception", ex, 0);
-        return new ResponseEntity(responseBody, HttpStatus.NOT_FOUND);
+        return new ResponseEntity<>(responseBody, HttpStatus.NOT_FOUND);
     }
 
     /**
@@ -83,7 +82,7 @@ public class ExceptionHandlerConfig {
         responseBody.put("timestamp", LocalDateTime.now());
         responseBody.put("message", "Bad request.");
         request.setAttribute("javax.servlet.error.exception", ex, 0);
-        return new ResponseEntity(responseBody, HttpStatus.BAD_REQUEST);
+        return new ResponseEntity<>(responseBody, HttpStatus.BAD_REQUEST);
     }
 
     /**
@@ -103,7 +102,7 @@ public class ExceptionHandlerConfig {
         responseBody.put("timestamp", LocalDateTime.now());
         responseBody.put("message", "Unable to process the request.");
         request.setAttribute("javax.servlet.error.exception", ex, 0);
-        return new ResponseEntity(responseBody, HttpStatus.METHOD_NOT_ALLOWED);
+        return new ResponseEntity<>(responseBody, HttpStatus.METHOD_NOT_ALLOWED);
     }
 
     /**
@@ -124,6 +123,6 @@ public class ExceptionHandlerConfig {
         responseBody.put("timestamp", LocalDateTime.now());
         responseBody.put("message", "Service unavailable.");
         request.setAttribute("javax.servlet.error.exception", ex, 0);
-        return new ResponseEntity(responseBody, HttpStatus.SERVICE_UNAVAILABLE);
+        return new ResponseEntity<>(responseBody, HttpStatus.SERVICE_UNAVAILABLE);
     }
 }

--- a/src/test/java/uk/gov/companieshouse/insolvency/data/controller/InsolvencyControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/insolvency/data/controller/InsolvencyControllerTest.java
@@ -37,7 +37,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @ExtendWith(SpringExtension.class)
 @WebMvcTest(controllers = InsolvencyController.class)
 @ContextConfiguration(classes = {InsolvencyController.class, ExceptionHandlerConfig.class})
-public class InsolvencyControllerTest {
+class InsolvencyControllerTest {
     private static final String COMPANY_NUMBER = "02588581";
     private static final String URL = String.format("/company/%s/insolvency", COMPANY_NUMBER);
 
@@ -169,12 +169,74 @@ public class InsolvencyControllerTest {
 
     @Test
     @DisplayName("Insolvency DELETE request")
-    public void callInsolvencyDeleteRequest() throws Exception {
+    void callInsolvencyDeleteRequest() throws Exception {
         doNothing().when(insolvencyService).deleteInsolvency(anyString(), anyString());
 
         mockMvc.perform(delete(URL)
                         .contentType(APPLICATION_JSON)
                         .header("x-request-id", "5342342"))
                 .andExpect(status().isOk());
+    }
+
+    @Test
+    @DisplayName("Insolvency DELETE request - IllegalArgumentException status code 404 not found")
+    void callInsolvencyDeleteRequestIllegalArgument() throws Exception {
+        doThrow(new IllegalArgumentException())
+                .when(insolvencyService).deleteInsolvency(anyString(), anyString());
+
+        mockMvc.perform(delete(URL)
+                        .contentType(APPLICATION_JSON)
+                        .header("x-request-id", "5342342"))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    @DisplayName("Insolvency DELETE request - BadRequestException status code 400")
+    void callInsolvencyDeleteRequestBadRequest() throws Exception {
+        doThrow(new BadRequestException("Bad request - data in wrong format"))
+                .when(insolvencyService).deleteInsolvency(anyString(), anyString());
+
+        mockMvc.perform(delete(URL)
+                        .contentType(APPLICATION_JSON)
+                        .header("x-request-id", "5342342"))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("Insolvency DELETE request - MethodNotAllowed status code 405")
+    void callInsolvencyDeleteRequestMethodNotAllowed() throws Exception {
+        doThrow(new MethodNotAllowedException(String.format("Method Not Allowed - unsuccessful call to %s endpoint", URL)))
+                .when(insolvencyService).deleteInsolvency(anyString(), anyString());
+
+        mockMvc.perform(delete(URL)
+                        .contentType(APPLICATION_JSON)
+                        .header("x-request-id", "5342342"))
+                .andExpect(status().isMethodNotAllowed());
+    }
+
+    @Test
+    @DisplayName("Insolvency DELETE request - InternalServerError status code 500")
+    void callInsolvencyDeleteRequestInternalServerError() throws Exception {
+
+        doThrow(new InternalServerErrorException("Internal Server Error - unexpected error"))
+                .when(insolvencyService).deleteInsolvency(anyString(), anyString());
+
+        mockMvc.perform(delete(URL)
+                        .contentType(APPLICATION_JSON)
+                        .header("x-request-id", "5342342"))
+                .andExpect(status().isInternalServerError());
+    }
+
+    @Test
+    @DisplayName("Insolvency DELETE request - ServiceUnavailable status code 503")
+    void callInsolvencyDeleteRequestServiceUnavailable() throws Exception {
+
+        doThrow(new ServiceUnavailableException("Service Unavailable - connection issues"))
+                .when(insolvencyService).deleteInsolvency(anyString(), anyString());
+
+        mockMvc.perform(delete(URL)
+                        .contentType(APPLICATION_JSON)
+                        .header("x-request-id", "5342342"))
+                .andExpect(status().isServiceUnavailable());
     }
 }

--- a/src/test/java/uk/gov/companieshouse/insolvency/data/service/InsolvencyServiceImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/insolvency/data/service/InsolvencyServiceImplTest.java
@@ -132,6 +132,31 @@ class InsolvencyServiceImplTest {
         verify(insolvencyApiService, times(1)).invokeChsKafkaApi(eq(contextId), eq(companyNumber), eq("deleted"));
     }
 
+    @Test
+    void when_connection_issue_in_db_on_delete_then_throw_service_unavailable_exception() {
+        String companyNumber = "CH363453";
+
+        Mockito.when(repository.findById(companyNumber)).thenReturn(Optional.of(new InsolvencyDocument()));
+        doThrow(new DataAccessResourceFailureException("Connection broken"))
+                .when(repository)
+                .deleteById(companyNumber);
+
+        Assert.assertThrows(ServiceUnavailableException.class, () ->
+                underTest.deleteInsolvency("436534543", companyNumber));
+    }
+
+    @Test
+    void when_connection_issue_in_db_on_find_in_delete_then_throw_service_unavailable_exception() {
+        String companyNumber = "CH363453";
+
+        doThrow(new DataAccessResourceFailureException("Connection broken"))
+                .when(repository)
+                .findById(companyNumber);
+
+        Assert.assertThrows(ServiceUnavailableException.class, () ->
+                underTest.deleteInsolvency("436534543", companyNumber));
+    }
+
     private InternalCompanyInsolvency createInternalCompanyInsolvency() {
         InternalCompanyInsolvency companyInsolvency = new InternalCompanyInsolvency();
         InternalData internalData = new InternalData();


### PR DESCRIPTION
Return non-200 error response codes arising during the call to the delete endpoint.

Code | Scenario
-- | --
400 - Bad request | When data is provided in the wrong format
500 - Internal Server Error | Any other unexpected error (should be handled in common error handler)
405 - Method not allowed | When someone calls a DELETE endpoint with a PATCH request
404 - Not found | When try to delete a document that does not exist
503 - Service Unavailable | MongoDB connection issues/chs-kafka-api connection issues

