### PR TITLE
DSND-929 - Return 410 when document is not found

### DIFF
--- a/src/itest/java/uk/gov/companieshouse/insolvency/data/steps/InsolvencySteps.java
+++ b/src/itest/java/uk/gov/companieshouse/insolvency/data/steps/InsolvencySteps.java
@@ -247,7 +247,7 @@ public class InsolvencySteps {
 
         Optional<InsolvencyDocument> actual = insolvencyRepository.findById(this.companyNumber);
 
-        assertThat(actual.isPresent()).isTrue();
+        assertThat(actual).isPresent();
 
         InsolvencyDocument expected = objectMapper.readValue(file, InsolvencyDocument.class);
 
@@ -292,7 +292,7 @@ public class InsolvencySteps {
     @Then("nothing is persisted in the database")
     public void nothing_persisted_database() {
         List<InsolvencyDocument> insolvencyDocuments = insolvencyRepository.findAll();
-        Assertions.assertThat(insolvencyDocuments).hasSize(0);
+        Assertions.assertThat(insolvencyDocuments).isEmpty();
     }
 
     private void verifyPutData(InsolvencyDocument actual, InsolvencyDocument expected) {

--- a/src/itest/resources/features/company-insolvency-delete.feature
+++ b/src/itest/resources/features/company-insolvency-delete.feature
@@ -21,7 +21,7 @@ Feature: Delete company insolvency information
     Given Insolvency data api service is running
     And the insolvency information exists for "CH3634545"
     When I send DELETE request with company number "CH1234567"
-    Then I should receive 404 status code
+    Then I should receive 410 status code
     And the CHS Kafka API is not invoked
 
   Scenario: Processing delete company insolvency without 'x-request-id' key in the header

--- a/src/itest/resources/features/company-insolvency-happy-path.feature
+++ b/src/itest/resources/features/company-insolvency-happy-path.feature
@@ -35,3 +35,10 @@ Feature: Process company insolvency information
       | companyNumber | result                     |
       | CH3634545     | retrieve_by_company_number |
 
+  Scenario: Retrieve company insolvency information unsuccessfully
+
+    Given Insolvency data api service is running
+    And the insolvency information exists for "CH3634545"
+    When I send GET request with company number "CH1234567"
+    Then I should receive 410 status code
+

--- a/src/main/java/uk/gov/companieshouse/insolvency/data/exceptions/DocumentGoneException.java
+++ b/src/main/java/uk/gov/companieshouse/insolvency/data/exceptions/DocumentGoneException.java
@@ -1,0 +1,8 @@
+package uk.gov.companieshouse.insolvency.data.exceptions;
+
+public class DocumentGoneException extends RuntimeException {
+
+    public DocumentGoneException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/insolvency/data/service/InsolvencyServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/insolvency/data/service/InsolvencyServiceImpl.java
@@ -16,6 +16,7 @@ import uk.gov.companieshouse.api.insolvency.InternalData;
 import uk.gov.companieshouse.insolvency.data.api.InsolvencyApiService;
 import uk.gov.companieshouse.insolvency.data.common.EventType;
 import uk.gov.companieshouse.insolvency.data.exceptions.BadRequestException;
+import uk.gov.companieshouse.insolvency.data.exceptions.DocumentGoneException;
 import uk.gov.companieshouse.insolvency.data.exceptions.ServiceUnavailableException;
 import uk.gov.companieshouse.insolvency.data.model.InsolvencyDocument;
 import uk.gov.companieshouse.insolvency.data.repository.InsolvencyRepository;
@@ -129,7 +130,7 @@ public class InsolvencyServiceImpl implements InsolvencyService {
                 insolvencyRepository.findById(companyNumber);
 
         InsolvencyDocument insolvencyDocument = insolvencyDocumentOptional.orElseThrow(
-                () -> new IllegalArgumentException(String.format(
+                () -> new DocumentGoneException(String.format(
                         "Resource not found for company number: %s", companyNumber)));
 
         return insolvencyDocument.getCompanyInsolvency();
@@ -142,7 +143,7 @@ public class InsolvencyServiceImpl implements InsolvencyService {
                     insolvencyRepository.findById(companyNumber);
 
             if (insolvencyDocumentOptional.isEmpty()) {
-                throw new IllegalArgumentException(String.format(
+                throw new DocumentGoneException(String.format(
                         "Company insolvency doesn't exist for company number %s",
                         companyNumber));
             }

--- a/src/main/java/uk/gov/companieshouse/insolvency/data/service/NoopTransactionServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/insolvency/data/service/NoopTransactionServiceImpl.java
@@ -14,6 +14,7 @@ import uk.gov.companieshouse.api.insolvency.InternalData;
 import uk.gov.companieshouse.insolvency.data.api.InsolvencyApiService;
 import uk.gov.companieshouse.insolvency.data.common.EventType;
 import uk.gov.companieshouse.insolvency.data.exceptions.BadRequestException;
+import uk.gov.companieshouse.insolvency.data.exceptions.DocumentGoneException;
 import uk.gov.companieshouse.insolvency.data.exceptions.ServiceUnavailableException;
 import uk.gov.companieshouse.insolvency.data.model.InsolvencyDocument;
 import uk.gov.companieshouse.insolvency.data.repository.InsolvencyRepository;
@@ -120,7 +121,7 @@ public class NoopTransactionServiceImpl implements InsolvencyService {
                 insolvencyRepository.findById(companyNumber);
 
         InsolvencyDocument insolvencyDocument = insolvencyDocumentOptional.orElseThrow(
-                () -> new IllegalArgumentException(String.format(
+                () -> new DocumentGoneException(String.format(
                         "Resource not found for company number: %s", companyNumber)));
 
         return insolvencyDocument.getCompanyInsolvency();
@@ -133,7 +134,7 @@ public class NoopTransactionServiceImpl implements InsolvencyService {
                     insolvencyRepository.findById(companyNumber);
 
             if (insolvencyDocumentOptional.isEmpty()) {
-                throw new IllegalArgumentException(String.format(
+                throw new DocumentGoneException(String.format(
                         "Company insolvency doesn't exist for company number %s",
                         companyNumber));
             }

--- a/src/test/java/uk/gov/companieshouse/insolvency/data/api/InsolvencyApiClientServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/insolvency/data/api/InsolvencyApiClientServiceTest.java
@@ -29,7 +29,7 @@ import java.util.stream.Stream;
 import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
-public class InsolvencyApiClientServiceTest {
+class InsolvencyApiClientServiceTest {
 
     @Mock
     private ApiClientService apiClientService;
@@ -62,6 +62,26 @@ public class InsolvencyApiClientServiceTest {
 
         ApiResponse<?> apiResponse = insolvencyApiService.invokeChsKafkaApi("35234234",
                 getInsolvencyDocument(), EventType.CHANGED);
+
+        Assertions.assertThat(apiResponse).isNotNull();
+
+        verify(apiClientService, times(1)).getInternalApiClient();
+        verify(internalApiClient, times(1)).privateChangedResourceHandler();
+        verify(privateChangedResourceHandler, times(1)).postChangedResource(Mockito.any(),
+                Mockito.any());
+        verify(changedResourcePost, times(1)).execute();
+    }
+
+    @Test
+    void should_invoke_chs_kafka_endpoint_delete_successfully() throws ApiErrorResponseException {
+
+        when(apiClientService.getInternalApiClient()).thenReturn(internalApiClient);
+        when(internalApiClient.privateChangedResourceHandler()).thenReturn(privateChangedResourceHandler);
+        when(privateChangedResourceHandler.postChangedResource(Mockito.any(), Mockito.any())).thenReturn(changedResourcePost);
+        when(changedResourcePost.execute()).thenReturn(response);
+
+        ApiResponse<?> apiResponse = insolvencyApiService.invokeChsKafkaApi("35234234",
+                getInsolvencyDocument(), EventType.DELETED);
 
         Assertions.assertThat(apiResponse).isNotNull();
 

--- a/src/test/java/uk/gov/companieshouse/insolvency/data/config/ExceptionHandlerConfigTest.java
+++ b/src/test/java/uk/gov/companieshouse/insolvency/data/config/ExceptionHandlerConfigTest.java
@@ -1,0 +1,142 @@
+package uk.gov.companieshouse.insolvency.data.config;
+
+import com.google.gson.Gson;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.MediaType;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.test.web.servlet.result.MockMvcResultHandlers;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.request.WebRequest;
+import uk.gov.companieshouse.api.insolvency.InternalCompanyInsolvency;
+import uk.gov.companieshouse.insolvency.data.controller.InsolvencyController;
+import uk.gov.companieshouse.insolvency.data.exceptions.BadRequestException;
+import uk.gov.companieshouse.insolvency.data.exceptions.DocumentGoneException;
+import uk.gov.companieshouse.insolvency.data.exceptions.MethodNotAllowedException;
+import uk.gov.companieshouse.insolvency.data.exceptions.ServiceUnavailableException;
+import uk.gov.companieshouse.logging.Logger;
+
+import java.lang.reflect.Constructor;
+import java.util.stream.Stream;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class ExceptionHandlerConfigTest {
+
+    private static final String X_REQUEST_ID_VALUE = "b74566ce-da4e-41f9-bda5-2e672eff8733";
+
+    private static final String X_REQUEST_ID = "x-request-id";
+
+    private MockMvc mockMvc;
+
+    @Mock
+    private Logger logger;
+
+    @InjectMocks
+    private ExceptionHandlerConfig exceptionHandlerConfig;
+
+    @Mock
+    private WebRequest webRequest;
+
+    @Mock
+    private InsolvencyController insolvencyController;
+
+    @Captor
+    private ArgumentCaptor<Exception> exceptionCaptor;
+
+    @Captor
+    private ArgumentCaptor<String> contextCaptor;
+
+    @Captor
+    private ArgumentCaptor<String> errMsgCaptor;
+
+    private final Gson gson = new Gson();
+
+    @BeforeEach
+    void setUp() throws IllegalArgumentException {
+        this.mockMvc =
+                MockMvcBuilders
+                        .standaloneSetup(insolvencyController)
+                        .setControllerAdvice(exceptionHandlerConfig)
+                        .build();
+
+        doNothing().when(logger).errorContext(
+                contextCaptor.capture(), errMsgCaptor.capture(), exceptionCaptor.capture(), any());
+    }
+
+    /**
+     * Verifies the response exception status as well as whether the expected context-id,
+     * message and exception itself have been passed to the logger.
+     */
+    @ParameterizedTest
+    @MethodSource("provideExceptionParameters")
+    void testHandleExceptionsUsingExceptionHandler(int expectedStatus, String expectedMsg,
+                                                   Class<Throwable> exceptionClass) throws Exception {
+        given(insolvencyController.insolvency(anyString(), anyString(), any()))
+                .willAnswer(
+                        invocation -> {
+                            Constructor<Throwable> constr =
+                                    exceptionClass.getDeclaredConstructor(String.class);
+                            throw constr.newInstance("Error!");
+                        }
+                );
+
+        verifyResponseStatus(performPutRequest(), expectedStatus);
+
+        verify(logger).errorContext(
+                contextCaptor.capture(), errMsgCaptor.capture(), exceptionCaptor.capture(), any());
+
+        assertThat(exceptionCaptor.getValue(), instanceOf(exceptionClass));
+        Assertions.assertEquals(expectedMsg, errMsgCaptor.getValue());
+        Assertions.assertEquals(X_REQUEST_ID_VALUE, contextCaptor.getValue());
+    }
+
+    private static Stream<Arguments> provideExceptionParameters() {
+        return Stream.of(
+                Arguments.of(400, "Bad request", BadRequestException.class),
+                Arguments.of(400, "Bad request", HttpMessageNotReadableException.class),
+                Arguments.of(405, "Unable to process the request, method not allowed",
+                        MethodNotAllowedException.class),
+                Arguments.of(410, "Resource gone", DocumentGoneException.class),
+                Arguments.of(500, "Unexpected exception", RuntimeException.class),
+                Arguments.of(500, "Unexpected exception", IllegalArgumentException.class),
+                Arguments.of(503, "Service unavailable", ServiceUnavailableException.class)
+        );
+    }
+
+    private void verifyResponseStatus(MockHttpServletResponse response, int expectedStatus) {
+        Assertions.assertEquals(expectedStatus, response.getStatus());
+    }
+
+    private MockHttpServletResponse performPutRequest() throws Exception {
+        InternalCompanyInsolvency companyInsolvency = new InternalCompanyInsolvency();
+
+        return mockMvc.perform(MockMvcRequestBuilders
+                        .put("/company/12345678/insolvency")
+                        .header(X_REQUEST_ID, X_REQUEST_ID_VALUE)
+                        .header("ERIC-Identity" , "SOME_IDENTITY")
+                        .header("ERIC-Identity-Type", "key")
+                        .content(gson.toJson(companyInsolvency))
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andDo(MockMvcResultHandlers.log()).andReturn().getResponse();
+    }
+}

--- a/src/test/java/uk/gov/companieshouse/insolvency/data/service/InsolvencyServiceImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/insolvency/data/service/InsolvencyServiceImplTest.java
@@ -20,6 +20,7 @@ import uk.gov.companieshouse.api.insolvency.InternalData;
 import uk.gov.companieshouse.insolvency.data.api.InsolvencyApiService;
 import uk.gov.companieshouse.insolvency.data.common.EventType;
 import uk.gov.companieshouse.insolvency.data.exceptions.BadRequestException;
+import uk.gov.companieshouse.insolvency.data.exceptions.DocumentGoneException;
 import uk.gov.companieshouse.insolvency.data.exceptions.ServiceUnavailableException;
 import uk.gov.companieshouse.insolvency.data.model.InsolvencyDocument;
 import uk.gov.companieshouse.insolvency.data.repository.InsolvencyRepository;
@@ -108,15 +109,15 @@ class InsolvencyServiceImplTest {
     }
 
     @Test
-    void when_company_number_doesnt_exist_then_throws_IllegalArgumentExceptionException_error() {
+    void when_company_number_doesnt_exist_then_throws_DocumentGoneException_error() {
         String companyNumber = "CH363453";
         Mockito.when(repository.findById(companyNumber)).thenReturn(Optional.empty());
 
-        Assert.assertThrows(IllegalArgumentException.class, () ->
+        Assert.assertThrows(DocumentGoneException.class, () ->
                 underTest.deleteInsolvency(companyNumber, companyNumber));
 
         verify(repository, Mockito.times(0)).deleteById(Mockito.any());
-        verify(repository, Mockito.times(1)).findById(Mockito.eq(companyNumber));
+        verify(repository, Mockito.times(1)).findById(companyNumber);
         verify(insolvencyApiService, times(0)).invokeChsKafkaApi(anyString(), any(), any());
     }
 
@@ -134,8 +135,8 @@ class InsolvencyServiceImplTest {
                         companyNumber)
         );
         verify(repository, Mockito.times(1)).deleteById(Mockito.any());
-        verify(repository, Mockito.times(1)).findById(Mockito.eq(companyNumber));
-        verify(insolvencyApiService, times(1)).invokeChsKafkaApi(eq(contextId), eq(document), eq(EventType.DELETED));
+        verify(repository, Mockito.times(1)).findById(companyNumber);
+        verify(insolvencyApiService, times(1)).invokeChsKafkaApi(contextId, document, EventType.DELETED);
     }
 
     @Test


### PR DESCRIPTION
- Return a 410 (Gone) response code if the insolvency document is not found in the database for a given company number across all endpoints doing a get call to the db.
  - change integration tests to return the new status code 410 in this scenario
- Refactor of the Global exception handler class - unifies error handling approach with that in `company-profile-api`
  - simplifies error handling through component reuse
  - can now pass contextId to each error
  - increased test coverage - global exception handler tests now cover all custom error handlers with added scenarios for any other exception not covered (intercepted by handleException)
- addresses Sonar-flagged issues across the repository

Resolves:
[DSND-929](https://companieshouse.atlassian.net/browse/DSND-929)