### PR TITLE
Remove persistance for status field

### DIFF
--- a/Tiltfile.dev
+++ b/Tiltfile.dev
@@ -4,7 +4,7 @@ local_resource(
     deps = ['src']
   )
   
-  custom_build(
+custom_build(
     ref = '169942020521.dkr.ecr.eu-west-1.amazonaws.com/insolvency-data-api',
     command = 'mvn compile jib:dockerBuild -Dimage=$EXPECTED_REF',
     live_update = [
@@ -15,4 +15,4 @@ local_resource(
       restart_container()
     ],
     deps = ['./target/classes']
-  )
+)

--- a/src/main/java/uk/gov/companieshouse/insolvency/data/service/InsolvencyServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/insolvency/data/service/InsolvencyServiceImpl.java
@@ -4,7 +4,6 @@ import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.util.Optional;
 
-import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.dao.DataAccessException;
 import org.springframework.stereotype.Service;
 import uk.gov.companieshouse.GenerateEtagUtil;
@@ -63,14 +62,6 @@ public class InsolvencyServiceImpl implements InsolvencyService {
                     insolvencyDocument.setDeltaAt(dateFromBodyRequest);
                     insolvencyDocument.setUpdatedAt(LocalDateTime.now());
                     insolvencyDocument.getCompanyInsolvency().setStatus(null);
-
-                    var statusFromDb = Optional.ofNullable(
-                                    insolvencyDocumentFromDb.getCompanyInsolvency())
-                            .map(CompanyInsolvency::getStatus);
-
-                    if (statusFromDb.isPresent() && !statusFromDb.get().isEmpty()) {
-                        insolvencyDocument.getCompanyInsolvency().setStatus(statusFromDb.get());
-                    }
 
                     insolvencyApiService.invokeChsKafkaApi(contextId, insolvencyDocument,
                             EventType.CHANGED);


### PR DESCRIPTION
This PR removes the status persistance check from the insolvency service so that it will be null on every insolvency processed and set later by the company_profile delta.

**Resolves**
DSND-990