### PR TITLE
DSND-2731: Process status for GET and PUT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
 
 		<!-- Internal -->
 		<structured-logging.version>3.0.3</structured-logging.version>
-		<private-api-sdk-java.version>unversioned</private-api-sdk-java.version>
+		<private-api-sdk-java.version>4.0.150</private-api-sdk-java.version>
 		<api-sdk-manager-java-library.version>3.0.5</api-sdk-manager-java-library.version>
 		<api-helper-java-library.version>3.0.1</api-helper-java-library.version>
 

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
 
 		<!-- Internal -->
 		<structured-logging.version>3.0.3</structured-logging.version>
-		<private-api-sdk-java.version>4.0.76</private-api-sdk-java.version>
+		<private-api-sdk-java.version>unversioned</private-api-sdk-java.version>
 		<api-sdk-manager-java-library.version>3.0.5</api-sdk-manager-java-library.version>
 		<api-helper-java-library.version>3.0.1</api-helper-java-library.version>
 

--- a/src/itest/java/uk/gov/companieshouse/insolvency/data/steps/InsolvencySteps.java
+++ b/src/itest/java/uk/gov/companieshouse/insolvency/data/steps/InsolvencySteps.java
@@ -269,6 +269,7 @@ public class InsolvencySteps {
 
         // Verify that the time inserted is after the input
         assertThat(actualDocument.getUpdatedAt()).isAfter(expected.getUpdatedAt());
+        assertThat(actualDocument.getCompanyInsolvency().getStatus()).isEqualTo(expected.getCompanyInsolvency().getStatus());
 
         // Matching both updatedAt since it will never match the output (Uses now time)
         LocalDateTime replacedLocalDateTime = LocalDateTime.now();

--- a/src/itest/resources/features/company-insolvency-happy-path.feature
+++ b/src/itest/resources/features/company-insolvency-happy-path.feature
@@ -14,6 +14,20 @@ Feature: Process company insolvency information
       | case_type_compulsory_liquidation | case_type_compulsory_liquidation_output |
       | case_type_receivership           | case_type_receivership_output           |
 
+  Scenario Outline: Update existing company insolvency by unsetting the status field
+
+    Given Insolvency data api service is running
+    And the CHS Kafka API is reachable
+    And the insolvency information exists for "<companyNumber>"
+    When I send PUT request with payload "<data>" file
+    Then I should receive 200 status code
+    And the expected result should match "<result>" file
+    And the CHS Kafka API is invoked successfully with event "changed"
+
+    Examples:
+      | companyNumber  | data                                       | result                                            |
+      | CH5324324      | case_type_compulsory_liquidation_no_status | case_type_compulsory_liquidation_no_status_output |
+
   Scenario Outline: Processing company insolvency information no eric headers
 
     Given Insolvency data api service is running

--- a/src/itest/resources/json/input/case_type_compulsory_liquidation_no_status.json
+++ b/src/itest/resources/json/input/case_type_compulsory_liquidation_no_status.json
@@ -1,0 +1,44 @@
+{
+  "external_data": {
+    "etag": "etag",
+    "cases": [
+      {
+        "type": "compulsory-liquidation",
+        "dates": [
+          {
+            "type": "instrumented-on",
+            "date": "2022-01-01"
+          }
+        ],
+        "practitioners": [
+          {
+            "name": "practitioner name",
+            "address": {
+              "address_line_1": "address1",
+              "postal_code": "AB1 9YZ",
+              "address_line_2": "addressLine",
+              "locality": "locality",
+              "region": "region",
+              "country": "UK"
+            },
+            "appointed_on": "2022-01-01",
+            "ceased_to_act_on": "2022-01-01",
+            "role": "receiver"
+          }
+        ],
+        "notes": [
+          "test"
+        ],
+        "links": {
+          "charge": "charge"
+        },
+        "number": "3"
+      }
+    ]
+  },
+  "internal_data": {
+    "delta_at": "2023-03-08T17:14:48.263+00:00",
+    "company_number": "CH5324324",
+    "updated_by": "someone"
+  }
+}

--- a/src/itest/resources/json/output/case_type_compulsory_liquidation_no_status_output.json
+++ b/src/itest/resources/json/output/case_type_compulsory_liquidation_no_status_output.json
@@ -1,0 +1,43 @@
+{
+  "id": "CH5324324",
+  "companyInsolvency": {
+    "etag": "etag",
+    "cases": [
+      {
+        "type": "compulsory-liquidation",
+        "dates": [
+          {
+            "type": "instrumented-on",
+            "date": "2022-01-01"
+          }
+        ],
+        "notes": [
+          "test"
+        ],
+        "practitioners": [
+          {
+            "name": "practitioner name",
+            "address": {
+              "address_line_1": "address1",
+              "address_line_2": "addressLine",
+              "locality": "locality",
+              "region": "region",
+              "postal_code": "AB1 9YZ",
+              "country": "UK"
+            },
+            "appointed_on": "2022-01-01",
+            "ceased_to_act_on": "2022-01-01",
+            "role": "receiver"
+          }
+        ],
+        "links": {
+          "charge": "charge"
+        },
+        "number": "3"
+      }
+    ]
+  },
+  "updatedAt": "2022-03-08T17:14:48.263Z",
+  "updatedBy": "someone",
+  "deltaAt": "2023-03-08T17:14:48.263Z"
+}

--- a/src/main/java/uk/gov/companieshouse/insolvency/data/service/InsolvencyServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/insolvency/data/service/InsolvencyServiceImpl.java
@@ -64,7 +64,6 @@ public class InsolvencyServiceImpl implements InsolvencyService {
 
             insolvencyApiService.invokeChsKafkaApi(contextId, insolvencyDocument,
                     EventType.CHANGED);
-
             logger.info(String.format(
                     "ChsKafka api CHANGED invoked successfully for context id %s and company number %s",
                     contextId,

--- a/src/main/java/uk/gov/companieshouse/insolvency/data/service/InsolvencyServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/insolvency/data/service/InsolvencyServiceImpl.java
@@ -61,7 +61,6 @@ public class InsolvencyServiceImpl implements InsolvencyService {
                         deltaAtFromDbStr)) {
                     insolvencyDocument.setDeltaAt(dateFromBodyRequest);
                     insolvencyDocument.setUpdatedAt(LocalDateTime.now());
-                    insolvencyDocument.getCompanyInsolvency().setStatus(null);
 
                     insolvencyApiService.invokeChsKafkaApi(contextId, insolvencyDocument,
                             EventType.CHANGED);
@@ -85,7 +84,6 @@ public class InsolvencyServiceImpl implements InsolvencyService {
             } else {
                 insolvencyDocument.setDeltaAt(dateFromBodyRequest);
                 insolvencyDocument.setUpdatedAt(LocalDateTime.now());
-                insolvencyDocument.getCompanyInsolvency().setStatus(null);
 
                 insolvencyApiService.invokeChsKafkaApi(contextId, insolvencyDocument,
                         EventType.CHANGED);

--- a/src/main/java/uk/gov/companieshouse/insolvency/data/service/InsolvencyServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/insolvency/data/service/InsolvencyServiceImpl.java
@@ -48,7 +48,7 @@ public class InsolvencyServiceImpl implements InsolvencyService {
 
             insolvencyDocumentFromDbOptional
                     .ifPresent(existingDocument -> {
-                                if (dateFromBodyRequest.isBefore(existingDocument.getDeltaAt())) {
+                                if (!dateFromBodyRequest.isAfter(existingDocument.getDeltaAt())) {
                                     logger.info("Insolvency not persisted as the record provided is older"
                                             + " than the one already stored.");
                                     throw new IllegalArgumentException("Stale delta at");

--- a/src/main/java/uk/gov/companieshouse/insolvency/data/service/InsolvencyServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/insolvency/data/service/InsolvencyServiceImpl.java
@@ -48,7 +48,7 @@ public class InsolvencyServiceImpl implements InsolvencyService {
 
             insolvencyDocumentFromDbOptional
                     .ifPresent(existingDocument -> {
-                                if (!dateFromBodyRequest.isAfter(existingDocument.getDeltaAt())) {
+                                if (dateFromBodyRequest.isBefore(existingDocument.getDeltaAt())) {
                                     logger.info("Insolvency not persisted as the record provided is older"
                                             + " than the one already stored.");
                                     throw new IllegalArgumentException("Stale delta at");

--- a/src/main/java/uk/gov/companieshouse/insolvency/data/service/InsolvencyServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/insolvency/data/service/InsolvencyServiceImpl.java
@@ -65,16 +65,14 @@ public class InsolvencyServiceImpl implements InsolvencyService {
             insolvencyApiService.invokeChsKafkaApi(contextId, insolvencyDocument,
                     EventType.CHANGED);
 
-            logger.info(String.format("ChsKafka api CHANGED invoked "
-                            + "updating successfully for context id %s "
-                            + "and company number %s",
+            logger.info(String.format(
+                    "ChsKafka api CHANGED invoked successfully for context id %s and company number %s",
                     contextId,
                     companyNumber));
 
             insolvencyRepository.save(insolvencyDocument);
             logger.info(String.format(
-                    "Company insolvency is updated in MongoDB "
-                            + "with context id %s and company number %s",
+                    "Company insolvency successfully upserted in MongoDB with context id %s and company number %s",
                     contextId,
                     companyNumber));
 

--- a/src/main/java/uk/gov/companieshouse/insolvency/data/service/InsolvencyServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/insolvency/data/service/InsolvencyServiceImpl.java
@@ -91,11 +91,6 @@ public class InsolvencyServiceImpl implements InsolvencyService {
                 () -> new DocumentNotFoundException(String.format(
                         "Resource not found for company number: %s", companyNumber)));
 
-        CompanyInsolvency companyInsolvency = insolvencyDocument.getCompanyInsolvency();
-        if (companyInsolvency.getStatus().isEmpty()) {
-            companyInsolvency.setStatus(null);
-        }
-
         return insolvencyDocument.getCompanyInsolvency();
     }
 

--- a/src/main/java/uk/gov/companieshouse/insolvency/data/service/InsolvencyServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/insolvency/data/service/InsolvencyServiceImpl.java
@@ -3,7 +3,6 @@ package uk.gov.companieshouse.insolvency.data.service;
 import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.util.Optional;
-
 import org.springframework.dao.DataAccessException;
 import org.springframework.stereotype.Service;
 import uk.gov.companieshouse.GenerateEtagUtil;
@@ -28,7 +27,8 @@ public class InsolvencyServiceImpl implements InsolvencyService {
 
     /**
      * Insolvency service to store the insolvency data onto mongodb and call chs kafka endpoint.
-     *  @param logger               the logger
+     *
+     * @param logger               the logger
      * @param insolvencyRepository mongodb repository
      * @param insolvencyApiService chs-kafka api service
      */
@@ -40,66 +40,44 @@ public class InsolvencyServiceImpl implements InsolvencyService {
     }
 
     @Override
-    public void processInsolvency(String contextId, String companyNumber,
-                                  InternalCompanyInsolvency companyInsolvency) {
-        InsolvencyDocument insolvencyDocument = mapInsolvencyDocument(
-                companyNumber, companyInsolvency);
-
+    public void processInsolvency(String contextId, String companyNumber, InternalCompanyInsolvency companyInsolvency) {
         try {
-
             Optional<InsolvencyDocument> insolvencyDocumentFromDbOptional =
                     insolvencyRepository.findById(companyNumber);
             OffsetDateTime dateFromBodyRequest = companyInsolvency.getInternalData().getDeltaAt();
 
-            if (insolvencyDocumentFromDbOptional.isPresent()) {
-                InsolvencyDocument insolvencyDocumentFromDb =
-                        insolvencyDocumentFromDbOptional.get();
+            insolvencyDocumentFromDbOptional
+                    .ifPresent(existingDocument -> {
+                                if (!dateFromBodyRequest.isAfter(existingDocument.getDeltaAt())) {
+                                    logger.info("Insolvency not persisted as the record provided is older"
+                                            + " than the one already stored.");
+                                    throw new IllegalArgumentException("Stale delta at");
+                                }
+                            }
+                    );
 
-                OffsetDateTime deltaAtFromDbStr = insolvencyDocumentFromDb.getDeltaAt();
+            InsolvencyDocument insolvencyDocument = mapInsolvencyDocument(
+                    companyNumber, companyInsolvency);
 
-                if (deltaAtFromDbStr == null || dateFromBodyRequest.isAfter(
-                        deltaAtFromDbStr)) {
-                    insolvencyDocument.setDeltaAt(dateFromBodyRequest);
-                    insolvencyDocument.setUpdatedAt(LocalDateTime.now());
+            insolvencyDocument.setDeltaAt(dateFromBodyRequest);
+            insolvencyDocument.setUpdatedAt(LocalDateTime.now());
 
-                    insolvencyApiService.invokeChsKafkaApi(contextId, insolvencyDocument,
-                            EventType.CHANGED);
+            insolvencyApiService.invokeChsKafkaApi(contextId, insolvencyDocument,
+                    EventType.CHANGED);
 
-                    logger.info(String.format("ChsKafka api CHANGED invoked "
-                                    + "updating successfully for context id %s "
-                                    + "and company number %s",
-                            contextId,
-                            companyNumber));
+            logger.info(String.format("ChsKafka api CHANGED invoked "
+                            + "updating successfully for context id %s "
+                            + "and company number %s",
+                    contextId,
+                    companyNumber));
 
-                    insolvencyRepository.save(insolvencyDocument);
-                    logger.info(String.format(
-                            "Company insolvency is updated in MongoDB "
-                                    + "with context id %s and company number %s",
-                            contextId,
-                            companyNumber));
-                } else {
-                    logger.info("Insolvency not persisted as the record provided is older"
-                            + " than the one already stored.");
-                }
-            } else {
-                insolvencyDocument.setDeltaAt(dateFromBodyRequest);
-                insolvencyDocument.setUpdatedAt(LocalDateTime.now());
+            insolvencyRepository.save(insolvencyDocument);
+            logger.info(String.format(
+                    "Company insolvency is updated in MongoDB "
+                            + "with context id %s and company number %s",
+                    contextId,
+                    companyNumber));
 
-                insolvencyApiService.invokeChsKafkaApi(contextId, insolvencyDocument,
-                        EventType.CHANGED);
-
-                logger.info(String.format("ChsKafka api CHANGED invoked "
-                                + "creating successfully for context id %s and company number %s",
-                        contextId,
-                        companyNumber));
-
-                insolvencyRepository.save(insolvencyDocument);
-                logger.info(String.format(
-                        "Company insolvency is inserted in MongoDB "
-                                + "with context id %s and company number %s",
-                        contextId,
-                        companyNumber));
-            }
         } catch (IllegalArgumentException illegalArgumentEx) {
             throw new BadRequestException(illegalArgumentEx.getMessage());
         } catch (DataAccessException dbException) {

--- a/src/test/java/uk/gov/companieshouse/insolvency/data/service/InsolvencyServiceImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/insolvency/data/service/InsolvencyServiceImplTest.java
@@ -79,7 +79,7 @@ class InsolvencyServiceImplTest {
         // then
         assertThrows(BadRequestException.class, executable);
         verifyNoInteractions(insolvencyApiService);
-        verify(repository, Mockito.times(0)).save(Mockito.any());
+        verify(repository, times(0)).save(any());
     }
 
     @Test

--- a/src/test/java/uk/gov/companieshouse/insolvency/data/service/InsolvencyServiceImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/insolvency/data/service/InsolvencyServiceImplTest.java
@@ -1,14 +1,27 @@
 package uk.gov.companieshouse.insolvency.data.service;
 
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.isA;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
 import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.util.Optional;
-
 import org.assertj.core.api.Assertions;
 import org.junit.Assert;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.function.Executable;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
@@ -26,9 +39,6 @@ import uk.gov.companieshouse.insolvency.data.model.InsolvencyDocument;
 import uk.gov.companieshouse.insolvency.data.repository.InsolvencyRepository;
 import uk.gov.companieshouse.logging.Logger;
 
-import static org.mockito.ArgumentMatchers.isA;
-import static org.mockito.Mockito.*;
-
 @ExtendWith(MockitoExtension.class)
 class InsolvencyServiceImplTest {
 
@@ -43,6 +53,34 @@ class InsolvencyServiceImplTest {
 
     @InjectMocks
     private InsolvencyServiceImpl underTest;
+
+    @ParameterizedTest
+    @CsvSource({
+            "2021-03-08T12:00:00.000Z , 2022-03-08T12:00:00.000Z",
+            "2022-03-08T12:00:00.000Z , 2022-03-08T12:00:00.000Z"
+    })
+    void when_request_is_stale_then_data_should_not_be_saved(OffsetDateTime requestDeltaAt, OffsetDateTime existingDeltaAt) {
+        // given
+        final String companyNumber = "CN123456";
+        final String contextId = "context_id";
+
+        InternalCompanyInsolvency internalCompanyInsolvency = createInternalCompanyInsolvency();
+        internalCompanyInsolvency.getInternalData().setDeltaAt(requestDeltaAt);
+
+        InsolvencyDocument existingDocument = new InsolvencyDocument();
+        existingDocument.setDeltaAt(existingDeltaAt);
+        Optional<InsolvencyDocument> existingDocumentOptional = Optional.of(existingDocument);
+
+        when(repository.findById(anyString())).thenReturn(existingDocumentOptional);
+
+        // when
+        Executable executable = () -> underTest.processInsolvency(contextId, companyNumber, internalCompanyInsolvency);
+
+        // then
+        assertThrows(BadRequestException.class, executable);
+        verifyNoInteractions(insolvencyApiService);
+        verify(repository, Mockito.times(0)).save(Mockito.any());
+    }
 
     @Test
     void when_insolvency_data_is_given_then_data_should_be_saved() {


### PR DESCRIPTION
This PR removes the setting of status field to null during a PUT request and ensures a null status is not returned as an empty status list in the GET response. A populated status field was already returned in the GET response, so no extra work required there.

Tested locally against the API only.

[DSND-2731](https://companieshouse.atlassian.net/browse/DSND-2731)

[DSND-2731]: https://companieshouse.atlassian.net/browse/DSND-2731?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ