### PR TITLE
DSND-2731: Set status to null in response when no status on Mongo doc

### DIFF
--- a/src/main/java/uk/gov/companieshouse/insolvency/data/service/InsolvencyServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/insolvency/data/service/InsolvencyServiceImpl.java
@@ -91,6 +91,11 @@ public class InsolvencyServiceImpl implements InsolvencyService {
                 () -> new DocumentNotFoundException(String.format(
                         "Resource not found for company number: %s", companyNumber)));
 
+        CompanyInsolvency companyInsolvency = insolvencyDocument.getCompanyInsolvency();
+        if (companyInsolvency.getStatus().isEmpty()) {
+            companyInsolvency.setStatus(null);
+        }
+
         return insolvencyDocument.getCompanyInsolvency();
     }
 


### PR DESCRIPTION
This PR ensures an empty status list is not returned in GET response when no status exists on the mongo doc.

[DSND-2731](https://companieshouse.atlassian.net/browse/DSND-2731)

[DSND-2731]: https://companieshouse.atlassian.net/browse/DSND-2731?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ