### PR TITLE
DSND-3040: Fix null pointer ex on existing delta at

### DIFF
--- a/src/main/java/uk/gov/companieshouse/insolvency/data/service/InsolvencyServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/insolvency/data/service/InsolvencyServiceImpl.java
@@ -33,7 +33,7 @@ public class InsolvencyServiceImpl implements InsolvencyService {
      * @param insolvencyApiService chs-kafka api service
      */
     public InsolvencyServiceImpl(Logger logger, InsolvencyRepository insolvencyRepository,
-                                 InsolvencyApiService insolvencyApiService) {
+            InsolvencyApiService insolvencyApiService) {
         this.logger = logger;
         this.insolvencyRepository = insolvencyRepository;
         this.insolvencyApiService = insolvencyApiService;
@@ -48,7 +48,8 @@ public class InsolvencyServiceImpl implements InsolvencyService {
 
             insolvencyDocumentFromDbOptional
                     .ifPresent(existingDocument -> {
-                                if (!dateFromBodyRequest.isAfter(existingDocument.getDeltaAt())) {
+                                if (existingDocument.getDeltaAt() != null
+                                        && !dateFromBodyRequest.isAfter(existingDocument.getDeltaAt())) {
                                     logger.info("Insolvency not persisted as the record provided is older"
                                             + " than the one already stored.");
                                     throw new IllegalArgumentException("Stale delta at");
@@ -125,7 +126,7 @@ public class InsolvencyServiceImpl implements InsolvencyService {
     }
 
     private InsolvencyDocument mapInsolvencyDocument(String companyNumber,
-                                                     InternalCompanyInsolvency insolvencyApi) {
+            InternalCompanyInsolvency insolvencyApi) {
         InternalData internalData = insolvencyApi.getInternalData();
         CompanyInsolvency externalData = insolvencyApi.getExternalData();
 


### PR DESCRIPTION
* Fix a bug where the check for a stale delta at throws a null pointer ex because the comparison is made against a null existing delta at on the existing mongo doc.
* Fix is to check if delta at is null first, before doing the stale delta at check.

[DSND-3040](https://companieshouse.atlassian.net/browse/DSND-3040)

[DSND-3040]: https://companieshouse.atlassian.net/browse/DSND-3040?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ