### PR TITLE
DSND-3022: Call Mongo before resource changed

### DIFF
--- a/src/itest/resources/features/company-insolvency-error-retry.feature
+++ b/src/itest/resources/features/company-insolvency-error-retry.feature
@@ -19,12 +19,12 @@ Feature: Error and retry scenarios for company insolvency
     When CHS kafka API service is unavailable
     And I send PUT request with payload "<data>" file
     Then I should receive 503 status code
-    And nothing is persisted in the database
+    And the expected result should match "<result>" file
     And the CHS Kafka API is invoked successfully with event "changed"
 
     Examples:
-      | data                             |
-      | case_type_compulsory_liquidation |
+      | data                             | result                                  |
+      | case_type_compulsory_liquidation | case_type_compulsory_liquidation_output |
 
   Scenario: Processing company insolvency information while database is down
 

--- a/src/test/java/uk/gov/companieshouse/insolvency/data/service/InsolvencyServiceImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/insolvency/data/service/InsolvencyServiceImplTest.java
@@ -58,7 +58,7 @@ class InsolvencyServiceImplTest {
     @ParameterizedTest
     @CsvSource({
             "2021-03-08T12:00:00.000Z , 2022-03-08T12:00:00.000Z",
-            "2022-03-08T12:00:00.000Z , 2022-03-08T12:00:00.000Z"
+            "2022-03-08T12:00:00.000Z , 2022-03-08T12:00:00.001Z"
     })
     void when_request_is_stale_then_data_should_not_be_saved(OffsetDateTime requestDeltaAt,
             OffsetDateTime existingDeltaAt) {
@@ -130,9 +130,7 @@ class InsolvencyServiceImplTest {
 
         Assert.assertThrows(ServiceUnavailableException.class, () ->
                 underTest.processInsolvency("436534543", "CH363453", companyInsolvency));
-        verify(insolvencyApiService, times(1)).invokeChsKafkaApi(anyString(), any(),
-                any());
-
+        verifyNoInteractions(insolvencyApiService);
     }
 
     @Test
@@ -160,7 +158,7 @@ class InsolvencyServiceImplTest {
 
         Assert.assertThrows(BadRequestException.class, () ->
                 underTest.processInsolvency("436534543", "CH363453", companyInsolvency));
-        verify(insolvencyApiService, times(1)).invokeChsKafkaApi(anyString(), any(), any());
+        verifyNoInteractions(insolvencyApiService);
     }
 
     @Test


### PR DESCRIPTION
* Changes order of operations so data is persisted in Mongo before calling the resource changed endpoint in chs-kafka-api.
* If the call to resource changed fails, any subsequent retries will now pass as a delta with the same delta_at as the existing document in Mongo is now considered latest.

[DSND-3022](https://companieshouse.atlassian.net/browse/DSND-3022)

[DSND-3022]: https://companieshouse.atlassian.net/browse/DSND-3022?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ