### PR TITLE
ASM-589: Fix CVE-2025-48924 by upgrading commons-lang3 to 3.18.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,6 +18,7 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 		<java.version>21</java.version>
+		<commons-lang3.version>3.18.0</commons-lang3.version>
 
 		<main.class>uk.gov.companieshouse.insolvency.data.InsolvencyDataApiApplication</main.class>
 
@@ -89,7 +90,13 @@
 				<type>pom</type>
 				<scope>import</scope>
 			</dependency>
-		</dependencies>
+			<!-- CVE-2025-48924 fix: override commons-lang3 to 3.18.0+ -->
+			<dependency>
+				<groupId>org.apache.commons</groupId>
+				<artifactId>commons-lang3</artifactId>
+				<version>${commons-lang3.version}</version>
+			</dependency>
+			</dependencies>
 	</dependencyManagement>
 
 	<dependencies>

--- a/src/main/java/uk/gov/companieshouse/insolvency/data/auth/EricTokenAuthenticationFilter.java
+++ b/src/main/java/uk/gov/companieshouse/insolvency/data/auth/EricTokenAuthenticationFilter.java
@@ -8,7 +8,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.util.Optional;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.ArrayUtils;
 import org.springframework.lang.NonNull;
 import org.springframework.web.filter.OncePerRequestFilter;

--- a/src/main/java/uk/gov/companieshouse/insolvency/data/serialization/CustomStringSerializer.java
+++ b/src/main/java/uk/gov/companieshouse/insolvency/data/serialization/CustomStringSerializer.java
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.JsonSerializer;
 import com.fasterxml.jackson.databind.SerializerProvider;
 import java.io.IOException;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 
 public class CustomStringSerializer extends JsonSerializer<String> {
 


### PR DESCRIPTION
- Override commons-lang3 version to 3.18.0 in dependencyManagement
- Migrate imports from deprecated org.apache.commons.lang to org.apache.commons.lang3 in EricTokenAuthenticationFilter and CustomStringSerializer

Dependency exclusions were not viable for this fix as testing showed they caused breaking changes in transitive dependencies. A sister commit with suppressions exists in the dependency-check-suppressions repository.